### PR TITLE
Update java version, mongodb version, nodejs version and add extra py…

### DIFF
--- a/packer/scripts/extras/java.sh
+++ b/packer/scripts/extras/java.sh
@@ -1,1 +1,1 @@
-dnf install -y --setopt=tsflags=nodocs --allowerasing ca-certificates procps wget java-1.8.0-openjdk-headless
+dnf install -y --setopt=tsflags=nodocs --allowerasing ca-certificates procps wget java-openjdk-headless

--- a/packer/scripts/extras/mongodb.sh
+++ b/packer/scripts/extras/mongodb.sh
@@ -1,12 +1,13 @@
 # Configure the package management system
 cat << EOF > /etc/yum.repos.d/mongodb-org-7.0.repo
-[mongodb-enterprise-7.0]
-name=MongoDB Enterprise Repository
-baseurl=https://repo.mongodb.com/yum/redhat/\$releasever/mongodb-enterprise/7.0/\$basearch/
+[mongodb-org-8.0]
+name=MongoDB Repository
+baseurl=https://repo.mongodb.org/yum/redhat/9/mongodb-org/8.0/x86_64/
 gpgcheck=1
 enabled=1
-gpgkey=https://www.mongodb.org/static/pgp/server-7.0.asc
+gpgkey=https://pgp.mongodb.com/server-8.0.asc
 EOF
 
+
 # Install the MongoDB packages
-dnf install -y mongodb-enterprise
+dnf install -y mongodb-org

--- a/packer/scripts/extras/mongodb.sh
+++ b/packer/scripts/extras/mongodb.sh
@@ -11,3 +11,4 @@ EOF
 
 # Install the MongoDB packages
 dnf install -y mongodb-org
+systemctl enable mongod

--- a/packer/scripts/extras/nodejs.sh
+++ b/packer/scripts/extras/nodejs.sh
@@ -1,1 +1,2 @@
-dnf install -y nodejs-16.*
+dnf module enable -y nodejs:22
+dnf install -y nodejs npm

--- a/packer/scripts/extras/postgresql.sh
+++ b/packer/scripts/extras/postgresql.sh
@@ -1,2 +1,3 @@
 dnf module install -y postgresql:15/server
+/usr/bin/postgresql-setup --initdb
 systemctl enable postgresql

--- a/packer/scripts/extras/postgresql.sh
+++ b/packer/scripts/extras/postgresql.sh
@@ -1,1 +1,2 @@
 dnf module install -y postgresql:15/server
+systemctl enable postgresql

--- a/packer/scripts/extras/python.sh
+++ b/packer/scripts/extras/python.sh
@@ -1,1 +1,1 @@
-dnf install -y python3
+dnf install -y python3 python3-devel python3-pip

--- a/packer/scripts/extras/rabbitmq.sh
+++ b/packer/scripts/extras/rabbitmq.sh
@@ -11,3 +11,4 @@ sslverify=0
 EOT
 
 dnf install -y rabbitmq-server-3.*
+systemctl enable rabbitmq-server

--- a/packer/scripts/extras/redis.sh
+++ b/packer/scripts/extras/redis.sh
@@ -1,1 +1,2 @@
 dnf install -y redis-6.*
+systemctl enable redis


### PR DESCRIPTION
1. Java -> now uses default java. RHEL 9.5 change default from 17
2. Mongodb -> 8.0 and change from enterprise to community
3. Nodejs -> change from 16 to 22 (newest available as the module)
4. Python now with:
   - devel packages
   - pip

Also the installed services are now enabled by default